### PR TITLE
Include newlines in regex message match

### DIFF
--- a/common/message-utils.js
+++ b/common/message-utils.js
@@ -11,7 +11,8 @@ function parseId(str) {
 }
 
 exports.parseTag = function(val) {
-  var m = /^([\dA-F]+)#(.*)$/.exec(val);
+  // [\s\S] instead of . because the val might include newlines
+  var m = /^([\dA-F]+)#([\s\S]*)$/.exec(val);
   if (!m) {
     return null;
   }


### PR DESCRIPTION
As suggested in http://stackoverflow.com/a/16119722/1133019, [\s\S] was the most intuitive form to me that was also performant.