### PR TITLE
var to let

### DIFF
--- a/lib/sockjs.js
+++ b/lib/sockjs.js
@@ -31,7 +31,7 @@ exports.createFactory = function(protocolChooser, options) {
 
     url = pathParams.reorderPathParams(url, ["n", "o", "t", "w", "s"]);
 
-    var whitelist = [];
+    let whitelist = [];
     protocolChooser.whitelist.forEach(prot => {
       if (!options.disableProtocols || options.disableProtocols.indexOf(prot) < 0) {
         whitelist.push(prot);


### PR DESCRIPTION
accidentally changed declaration of the protocol whitelist from `let` to `var`;
reverting this aspect of #8.