### PR TITLE
Look for Worker ID in alternative location

### DIFF
--- a/lib/decorators/worker-id.js
+++ b/lib/decorators/worker-id.js
@@ -32,7 +32,7 @@ exports.decorate = function(factory, options) {
 
     if (!worker) {
       // Check to see if we were assigned a base href
-      let base = global.jQuery('base').attr('href') || global.document.head.getAttribute('data-worker');
+      let base = global.jQuery('base').attr('href') || global.location.href;
       // Extract the worker ID if it's included in a larger URL.
       let mtch = base.match(/_w_(\w+)\//);
       base = mtch[1];

--- a/lib/decorators/worker-id.js
+++ b/lib/decorators/worker-id.js
@@ -32,7 +32,7 @@ exports.decorate = function(factory, options) {
 
     if (!worker) {
       // Check to see if we were assigned a base href
-      let base = global.jQuery('base').attr('href');
+      let base = global.jQuery('base').attr('href') || global.document.head.getAttribute('data-worker');
       // Extract the worker ID if it's included in a larger URL.
       let mtch = base.match(/_w_(\w+)\//);
       base = mtch[1];


### PR DESCRIPTION
Look for the worker-id in head[data-worker] in addition to base[href].

Connected to https://github.com/rstudio/connect/issues/7962
Connected to https://github.com/rstudio/connect/pull/8027

base[href] is no longer guaranteed to contain the worker ID as it
affects relative links contained in the Rmd.